### PR TITLE
Fix Incorrect Run Command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ execution. The required arguments for the tool are as follows:
 
 - `-t, --token`: Input a Github user token to allow `Pygithub` access to information
   such as the Issue Tracker.
-- `-r, --repo`: Input the GitHub Repository name that the User will be assessing (`username/repo_name`).
+- `-r, --repo`: Input the GitHub Repository name that the User will be assessing 
+(`username/repo_name`).
 
 Run the command `pipenv run python src/cogitate.py -t [GitHub Token] -r [Path]`
 in the root directory.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ execution. The required arguments for the tool are as follows:
 
 - `-t, --token`: Input a Github user token to allow `Pygithub` access to information
   such as the Issue Tracker.
-- `-r, --repo`: Input the GitHub Repository name that the User will be assessing 
-(`username/repo_name`).
+- `-r, --repo`: Input the GitHub Repository name (`username/repo_name`).
 
 Run the command `pipenv run python src/cogitate.py -t [GitHub Token] -r [Path]`
 in the root directory.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ execution. The required arguments for the tool are as follows:
   such as the Issue Tracker.
 - `-r, --repo`: Input the Repository path that the User will be assessing.
 
-Run the command `pipenv python run src/cogitate.py -t [GitHub Token] -r [Path]`
+Run the command `pipenv run python src/cogitate.py -t [GitHub Token] -r [Path]`
 in the root directory.
 Check out `cogitate.py` to see additional arguments that can be used..
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ execution. The required arguments for the tool are as follows:
 
 - `-t, --token`: Input a Github user token to allow `Pygithub` access to information
   such as the Issue Tracker.
-- `-r, --repo`: Input the Repository path that the User will be assessing.
+- `-r, --repo`: Input the GitHub Repository name that the User will be assessing (username/repo_name).
 
 Run the command `pipenv run python src/cogitate.py -t [GitHub Token] -r [Path]`
 in the root directory.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ execution. The required arguments for the tool are as follows:
 
 - `-t, --token`: Input a Github user token to allow `Pygithub` access to information
   such as the Issue Tracker.
-- `-r, --repo`: Input the GitHub Repository name that the User will be assessing (username/repo_name).
+- `-r, --repo`: Input the GitHub Repository name that the User will be assessing (`username/repo_name`).
 
 Run the command `pipenv run python src/cogitate.py -t [GitHub Token] -r [Path]`
 in the root directory.


### PR DESCRIPTION
Hi all, I noticed that the command to run the Cogitate Tool in the README is incorrect.

The version in master is: `pipenv python run src/cogitate.py -t [GitHub Token] -r [Path]`

`python` and `run` are in the incorrect order, which causes the error:
```
Usage: pipenv [OPTIONS] COMMAND [ARGS]...
Try "pipenv -h" for help.

Error: No such command "python".
```

The command should be: `pipenv run python src/cogitate.py -t [GitHub Token] -r [Path]`
This PR adds the correct command to the README.